### PR TITLE
allow baud rate to be passed from device ini file

### DIFF
--- a/mmeowlink/link_builder.py
+++ b/mmeowlink/link_builder.py
@@ -4,10 +4,10 @@ from mmeowlink.vendors.mmcommander_link import MMCommanderLink
 from mmeowlink.vendors.subg_rfspy_link import SubgRfspyLink
 
 class LinkBuilder():
-  def build(self, radio_type, port):
+  def build(self, radio_type, port, **kwds):
     if radio_type == 'mmcommander':
       return MMCommanderLink(port)
     elif radio_type == 'subg_rfspy':
-      return SubgRfspyLink(port)
+      return SubgRfspyLink(port, **kwds)
     else:
       raise UnknownLinkType("Unknown radio type '%s' - check parameters" % radio_type)

--- a/mmeowlink/vendors/mmeowlink.py
+++ b/mmeowlink/vendors/mmeowlink.py
@@ -32,6 +32,14 @@ def configure_app (app, parser):
     'port',
     help='Radio serial port. e.g. /dev/ttyACM0 or /dev/ttyMFD1'
   )
+  """
+  parser.add_argument(
+    '--baud',
+    type=int,
+    default=19200,
+    help='Baud rate {default}'
+  )
+  """
 
 def get_params(self, args):
   params = {key: args.__dict__.get(key) for key in (
@@ -57,8 +65,9 @@ def setup_medtronic_link (self):
   serial = self.device.get('serial')
   radio_type = self.device.get('radio_type')
   port = self.device.get('port')
+  baud = self.device.get('baud', 19200)
 
-  link = LinkBuilder().build(radio_type, port)
+  link = LinkBuilder().build(radio_type, port, baud=baud)
   self.pump = Pump(link, serial)
 
 import logging

--- a/mmeowlink/vendors/subg_rfspy_link.py
+++ b/mmeowlink/vendors/subg_rfspy_link.py
@@ -22,10 +22,10 @@ class SubgRfspyLink(SerialInterface):
   REPETITION_DELAY = 0
   MAX_REPETITION_BATCHSIZE = 250
 
-  def __init__(self, device):
+  def __init__(self, device, **kwds):
     self.timeout = 1
     self.device = device
-    self.speed = 19200
+    self.speed = int(kwds.get('baud', 19200))
     self.channel = 0
 
     self.open()


### PR DESCRIPTION
Setting `baud = FOO` in the device's ini file will configure the baud rate for
subg_rfspy_link's.

It turns out to not actually matter, for the usb firmware.