### PR TITLE
Add support for subg error handling code

### DIFF
--- a/mmeowlink/exceptions.py
+++ b/mmeowlink/exceptions.py
@@ -7,6 +7,9 @@ class InvalidPacketReceived(Exception):
 class MMCommanderNotWriteable(Exception):
   pass
 
+class SubgRfspyVersionNotSupported (Exception):
+  pass
+
 class PortNotFound(Exception):
   pass
 


### PR DESCRIPTION
- Added error-handling code support for subg_rfspy. We now raise a CommsException error in certain cases, which can then be handled with a retry.

To ensure compatibility, we now check the version of subg_rfspy is supported by mmeowlink at startup, and generate an error if the version is not supported.