### PR TITLE
Timeout handling

### DIFF
--- a/mmeowlink/vendors/serial_rf_spy.py
+++ b/mmeowlink/vendors/serial_rf_spy.py
@@ -60,6 +60,10 @@ class SerialRfSpy:
     return self.get_response(timeout=timeout)
 
   def send_command(self, command, param="", timeout=1):
+    if timeout is None or timeout <= 0:
+      # We don't want infinite hangs for things, as it'll lock up processing
+      raise CommsException("Timeout cannot be None, zero, or negative - coding error")
+
     self.ser.write_timeout = timeout
 
     self.ser.write(chr(command))
@@ -70,8 +74,13 @@ class SerialRfSpy:
 
     self.ser.write_timeout = self.default_write_timeout
 
-  def get_response(self, timeout=0):
+  def get_response(self, timeout=None):
     log.debug("get_response: timeout = %s" % str(timeout))
+
+    if timeout is None or timeout <= 0:
+      # We don't want infinite hangs for things, as it'll lock up processing
+      raise CommsException("Timeout cannot be None, zero, or negative - coding error")
+
     start = time.time()
     while 1:
       bytesToRead = self.ser.inWaiting()
@@ -88,7 +97,7 @@ class SerialRfSpy:
           log.debug("response = command interrupted, getting the next response")
           continue
         return r
-      if (timeout > 0) and (start + timeout < time.time()):
+      if (start + timeout < time.time()):
         log.debug("gave up waiting for response from subg_rfspy")
         return bytearray()
       time.sleep(0.005)

--- a/mmeowlink/vendors/subg_rfspy_link.py
+++ b/mmeowlink/vendors/subg_rfspy_link.py
@@ -18,7 +18,6 @@ io  = logging.getLogger( )
 log = io.getChild(__name__)
 
 class SubgRfspyLink(SerialInterface):
-  TIMEOUT = 1
   REPETITION_DELAY = 0
   MAX_REPETITION_BATCHSIZE = 250
   FREQ_XTAL = 24000000
@@ -87,7 +86,7 @@ class SubgRfspyLink(SerialInterface):
 
     if timeout == None:
       timeout = 0.5
-    
+
     timeout_ms = int(timeout * 1000)
 
 
@@ -120,6 +119,9 @@ class SubgRfspyLink(SerialInterface):
 
   def write( self, string, repetitions=1, repetition_delay=0, timeout=None ):
     rf_spy = self.serial_rf_spy
+
+    if timeout is None:
+      timeout = self.timeout
 
     remaining_messages = repetitions
     while remaining_messages > 0:
@@ -177,4 +179,7 @@ class SubgRfspyLink(SerialInterface):
     return self.handle_response(resp)
 
   def read( self, timeout=None ):
+    if timeout is None:
+      timeout = self.timeout
+
     return self.get_packet(timeout)['data']


### PR DESCRIPTION
(Based on https://github.com/oskarpearson/mmeowlink/pull/23 - please don't merge until that PR has been confirmed a-ok.)

Improved timeout handling

In certain cases mmtune would query the radio without a timeout. This would
cause an infinite hang if the radio or the serial port lost a packet.

We now require timeouts for all commands - and if any are supplied as 'None' we
use the default value.