### PR TITLE
[adjust_ww_frequencies] Change WW/EU frequency range

### DIFF
--- a/mmeowlink/mmtune.py
+++ b/mmeowlink/mmtune.py
@@ -7,8 +7,8 @@ from mmeowlink.vendors.subg_rfspy_link import SubgRfspyLink
 
 class MMTune:
   FREQ_RANGES = {
-    'US': { 'start': 916.5, 'end': 916.9, 'default': 916.630 },
-    'WW': { 'start': 867.5, 'end': 868.5, 'default': 868.328 }
+    'US': { 'start': 916.5, 'end': 916.9, 'default': 916.63 },
+    'WW': { 'start': 868.3, 'end': 868.9, 'default': 868.36 }
   }
 
   def __init__(self, link, pumpserial, radio_locale='US'):


### PR DESCRIPTION
The Medtronic site (URL below) says the frequency for the Guardian is 868.35 and
the USA pump is 916.5

Since the USA frequency is very well optimised, I've tried keeping a similar
size range to the USA frequency, starting close to the 868.35 value like the USA
range starts at 916.5.

I've extended it very slightly since I think the EU frequencies might have a
larger variance on the high side.

http://www.medtronicdiabetes.com/sites/default/files/library/download-library/user-guides/guardian_real_time_user_guide.pdf