### PR TITLE
[adjust_frequency_ranges] Change frequency range

### DIFF
--- a/mmeowlink/mmtune.py
+++ b/mmeowlink/mmtune.py
@@ -7,8 +7,8 @@ from mmeowlink.vendors.subg_rfspy_link import SubgRfspyLink
 
 class MMTune:
   FREQ_RANGES = {
-    'US': { 'start': 916.5, 'end': 916.9, 'default': 916.630 },
-    'WW': { 'start': 867.5, 'end': 868.5, 'default': 868.328 }
+    'US': { 'start': 916.300, 'end': 916.900, 'default': 916.630 },
+    'WW': { 'start': 868.150, 'end': 868.750, 'default': 868.328 }
   }
 
   def __init__(self, link, pumpserial, radio_locale='US'):
@@ -24,28 +24,11 @@ class MMTune:
     self.scan_range = self.FREQ_RANGES[self.radio_locale]
 
   def run(self):
-
-    ############################################################################
-    # Commented these out as they may be causing issues with certain pumps:
-    ############################################################################
-    # self.link.update_register(SubgRfspyLink.REG_MDMCFG4, 0xa9)
-    #
-    # # Sometimes getting lower ber with 0x07 here (default is 0x03)
-    # self.link.update_register(SubgRfspyLink.REG_AGCCTRL2, 0x07)
-    #
-    # self.link.update_register(SubgRfspyLink.REG_AGCCTRL1, 0x40)
-    #
-    # # With rx bw > 101kzHZ, this should be 0xB6, otherwise 0x56
-    # self.link.update_register(SubgRfspyLink.REG_FREND1, 0x56)
-    #
-    # # default (0x91) seems to work best
-    # #self.link.update_register(SubgRfspyLink.REG_AGCCTRL0, 0x91)
-
     #print "waking..."
     self.wakeup()
 
     #print "scanning..."
-    results = self.scan_over_freq(self.scan_range['start'], self.scan_range['end'], 20)
+    results = self.scan_over_freq(self.scan_range['start'], self.scan_range['end'], 25)
     results_sorted = list(reversed(sorted(results, key=lambda x: x[1:])))
 
     set_freq = self.scan_range['default']


### PR DESCRIPTION
Narrow down the EU/WW range, and increase the USA range.

Background:

The Medtronic site (URL below) says the frequency for the Guardian is 868.35 and
the USA pump is 916.5

Since the USA frequency is very well optimised, I've tried keeping a similar
size range to the USA frequency, starting close to the 868.35 value like the USA
range starts at 916.5.

There is at least one report of 916.5 being too low, so I've extended it on the
downside too.

I've also increased the number of increment to account for the wider range.
This will make the scan take a bit longer to complete.

http://www.medtronicdiabetes.com/sites/default/files/library/download-library/user-guides/guardian_real_time_user_guide.pdf