### PR TITLE
Update for wider compatibility

### DIFF
--- a/mmeowlink/mmtune.py
+++ b/mmeowlink/mmtune.py
@@ -72,7 +72,7 @@ class MMTune:
     error_count = 0
     rssi_readings = []
     for i in xrange(sample_size):
-      self.send_packet("a7" + self.pumpserial + "8d00") # Get Model
+      self.send_packet("a7" + self.pumpserial + "8000") # DO not use 8d00 (get model), as it fails on 512/712. Use 8000 (get history). 
       try:
         packet = self.get_packet(0.080)
         success_count += 1


### PR DESCRIPTION
Attempting to do an 8d00 command as the 'ping' packet fails on the 512/712 pumps.
Changing this command to 8000 (according to decocare, 'get history') produces correct functionality.