### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     #- python: 3.5
     #- python: 3.6
     - python: 3.7
-      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+group: travis_latest
+language: python
+cache: pip
+matrix:
+  include:
+    - python: 2.7
+    #- python: 3.5
+    #- python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down

--- a/mmeowlink/cli/bolus_app.py
+++ b/mmeowlink/cli/bolus_app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # PYTHON_ARGCOMPLETE_OK
 
+from __future__ import print_function
 from decocare import commands
 from decocare import lib
 from base_mmeowlink_app import BaseMMeowlinkApp
@@ -69,7 +70,7 @@ class BolusApp (BaseMMeowlinkApp):
       return
 
   def main (self, args):
-    print args
+    print(args)
     self.bolus(args);
 
   def bolus (self, args):

--- a/mmeowlink/cli/mmtune_app.py
+++ b/mmeowlink/cli/mmtune_app.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 
 from mmeowlink.mmtune import MMTune
@@ -25,4 +26,4 @@ class MMTuneApp(BaseMMeowlinkApp):
   def main(self, args):
     tuner = MMTune(self.link, args.serial, args.radio_locale)
     output = tuner.run()
-    print json.dumps(output, sort_keys=True,indent=4, separators=(',', ': '))
+    print(json.dumps(output, sort_keys=True,indent=4, separators=(',', ': ')))

--- a/mmeowlink/cli/rf_dump_app.py
+++ b/mmeowlink/cli/rf_dump_app.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from datetime import datetime
 
 from .. hex_handling import hexify
@@ -31,16 +32,16 @@ class RfDumpApp(BaseMMeowlinkApp):
   def main(self, args):
     while True:
       try:
-        if type(self.link) == SubgRfspyLink:
+        if isinstance(self.link, SubgRfspyLink):
           resp = self.link.get_packet(timeout=1)
           ts = datetime.now()
-          print "%s (%d db) - %s" % (ts, resp['rssi'], hexify(resp['data']).upper())
-        elif type(self.link) == MMCommanderLink:
+          print("%s (%d db) - %s" % (ts, resp['rssi'], hexify(resp['data']).upper()))
+        elif isinstance(self.link, MMCommanderLink):
           resp = self.link.read(timeout=1)
           ts = datetime.now()
-          print "%s (N/A db) - %s" % (ts, hexify(resp).upper())
+          print("%s (N/A db) - %s" % (ts, hexify(resp).upper()))
       except CommsException as e:
         pass
       except InvalidPacketReceived:
         ts = datetime.now()
-        print "%s (N/A db) - Corrupt packet" % ts
+        print("%s (N/A db) - Corrupt packet" % ts)

--- a/mmeowlink/detect_radio_comms.py
+++ b/mmeowlink/detect_radio_comms.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 
 from datetime import datetime
@@ -24,16 +25,16 @@ class DetectRadioComms(object):
       hex_string = None
 
       try:
-        if type(self.link) == SubgRfspyLink:
+        if isinstance(self.link, SubgRfspyLink):
           resp = self.link.get_packet(timeout=1)
           hex_string = hexify(resp['data']).upper()
-        elif type(self.link) == MMCommanderLink:
+        elif isinstance(self.link, MMCommanderLink):
           resp = self.link.read(timeout=1)
           hex_string = hexify(resp).upper()
       except CommsException as e:
         pass
       except InvalidPacketReceived:
-        print "%s (N/A db) - Corrupt packet" % datetime.now()
+        print("%s (N/A db) - Corrupt packet" % datetime.now())
 
       # EG:   A7 12 31 23 22 5D .. ..
       # POS:  01234567890123456789

--- a/mmeowlink/fuser.py
+++ b/mmeowlink/fuser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # From https://github.com/bewest/decoding-carelink/blob/314406d5d6025321dbe1a7d48a202b608df41c30/decocare/fuser.py
 # This still has race conditions, but is better than nothing for the moment,
 # as not all other apps use lock files
@@ -22,4 +23,4 @@ def in_use (device):
 if __name__ == '__main__':
   from scan import scan
   candidate = (sys.argv[1:2] or [scan( )]).pop( )
-  print in_use(candidate)
+  print(in_use(candidate))

--- a/mmeowlink/handlers/stick.py
+++ b/mmeowlink/handlers/stick.py
@@ -175,7 +175,7 @@ class Repeater (Sender):
     try:
       self.wait_for_ack(timeout=ack_wait_seconds)
       return True
-    except CommsException, InvalidPacketReceived:
+    except CommsException as InvalidPacketReceived:
       log.error("%s - Response not received - retrying" % time.time())
 
     return False

--- a/mmeowlink/mmtune.py
+++ b/mmeowlink/mmtune.py
@@ -6,6 +6,11 @@ from decocare.lib import CRC8
 from mmeowlink.exceptions import CommsException,InvalidPacketReceived
 from mmeowlink.vendors.subg_rfspy_link import SubgRfspyLink
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 class MMTune:
   FREQ_RANGES = {
     'US': { 'start': 916.300, 'end': 916.900, 'default': 916.630 },
@@ -17,7 +22,7 @@ class MMTune:
 
     # MMTune can only be used with the SubgRfspy firmware, as MMCommander
     # cannot change frequencies
-    assert type(link) == SubgRfspyLink
+    assert isinstance(link, SubgRfspyLink)
 
     self.pumpserial = pumpserial
     self.radio_locale = radio_locale

--- a/mmeowlink/vendors/serial_rf_spy.py
+++ b/mmeowlink/vendors/serial_rf_spy.py
@@ -38,84 +38,84 @@ io  = logging.getLogger( )
 log = io.getChild(__name__)
 
 class SerialRfSpy:
-  CMD_GET_STATE = 1
-  CMD_GET_VERSION = 2
-  CMD_GET_PACKET = 3
-  CMD_SEND_PACKET = 4
-  CMD_SEND_AND_LISTEN = 5
-  CMD_UPDATE_REGISTER = 6
-  CMD_RESET = 7
+    CMD_GET_STATE = 1
+    CMD_GET_VERSION = 2
+    CMD_GET_PACKET = 3
+    CMD_SEND_PACKET = 4
+    CMD_SEND_AND_LISTEN = 5
+    CMD_UPDATE_REGISTER = 6
+    CMD_RESET = 7
 
-  RFSPY_ERROR_TIMEOUT = 0xaa
-  RFSPY_ERROR_COMMAND_INTERRUPTED = 0xbb
-  RFSPY_ERROR_ZERO_DATA = 0xcc
+    RFSPY_ERROR_TIMEOUT = 0xaa
+    RFSPY_ERROR_COMMAND_INTERRUPTED = 0xbb
+    RFSPY_ERROR_ZERO_DATA = 0xcc
 
-  def __init__(self, ser):
-    self.default_write_timeout = 1
-    self.ser = ser
-    self.buf = bytearray()
+    def __init__(self, ser):
+        self.default_write_timeout = 1
+        self.ser = ser
+        self.buf = bytearray()
 
-  def do_command(self, command, param="", timeout=0):
-    self.send_command(command, param, timeout=timeout)
-    if command == self.CMD_RESET:
-	time.sleep(1)
-    return self.get_response(timeout=timeout)
+    def do_command(self, command, param="", timeout=0):
+        self.send_command(command, param, timeout=timeout)
+        if command == self.CMD_RESET:
+            time.sleep(1)
+        return self.get_response(timeout=timeout)
 
-  def send_command(self, command, param="", timeout=1):
-    if timeout is None or timeout <= 0:
-      # We don't want infinite hangs for things, as it'll lock up processing
-      raise CommsException("Timeout cannot be None, zero, or negative - coding error")
+    def send_command(self, command, param="", timeout=1):
+        if timeout is None or timeout <= 0:
+            # We don't want infinite hangs for things, as it'll lock up processing
+            raise CommsException("Timeout cannot be None, zero, or negative - coding error")
 
-    self.ser.write_timeout = timeout
+        self.ser.write_timeout = timeout
 
-    cmd_str = chr(command) + param
+        cmd_str = chr(command) + param
 
-    self.ser.write(cmd_str)
-    log.debug("command: " + cmd_str)
-    #if len(param) > 0:
-    #  log.debug("params: %s" % str(param).encode('hex'))
-    #  self.ser.write(param)
+        self.ser.write(cmd_str)
+        log.debug("command: " + cmd_str)
+        #if len(param) > 0:
+        #  log.debug("params: %s" % str(param).encode('hex'))
+        #  self.ser.write(param)
 
-    self.ser.write_timeout = self.default_write_timeout
+        self.ser.write_timeout = self.default_write_timeout
 
-  def get_response(self, timeout=None):
-    log.debug("get_response: timeout = %s" % str(timeout))
+    def get_response(self, timeout=None):
+        log.debug("get_response: timeout = %s" % str(timeout))
 
-    if timeout is None or timeout <= 0:
-      # We don't want infinite hangs for things, as it'll lock up processing
-      raise CommsException("Timeout cannot be None, zero, or negative - coding error")
+        if timeout is None or timeout <= 0:
+            # We don't want infinite hangs for things, as it'll lock up processing
+            raise CommsException("Timeout cannot be None, zero, or negative - coding error")
 
-    start = time.time()
-    while 1:
-      bytesToRead = self.ser.inWaiting()
-      if bytesToRead > 0:
-        self.buf.extend(self.ser.read(bytesToRead))
-        log.debug("buf = %s" % str(self.buf).encode('hex'))
-      eop = self.buf.find(b'\x00',0)
-      if eop >= 0:
-        r = self.buf[:eop]
-        del self.buf[:(eop+1)]
-        if len(r) == 0:
-          return bytearray()
-        if len(r) <= 2 and r[0] == self.RFSPY_ERROR_COMMAND_INTERRUPTED:
-          log.debug("response = command interrupted, getting the next response")
-          continue
-        return r
-      if (start + timeout < time.time()):
-        log.debug("gave up waiting for response from subg_rfspy")
-        return bytearray()
-      time.sleep(0.005)
+        start = time.time()
+        while True:
+            bytesToRead = self.ser.inWaiting()
+            if bytesToRead > 0:
+                self.buf.extend(self.ser.read(bytesToRead))
+                log.debug("buf = %s" % str(self.buf).encode('hex'))
+            eop = self.buf.find(b'\x00',0)
+            if eop >= 0:
+                r = self.buf[:eop]
+                del self.buf[:(eop+1)]
+                if len(r) == 0:
+                    return bytearray()
+                if len(r) <= 2 and r[0] == self.RFSPY_ERROR_COMMAND_INTERRUPTED:
+                    log.debug("response = command interrupted, getting the next response")
+                    continue
+                return r
+            if (start + timeout < time.time()):
+                log.debug("gave up waiting for response from subg_rfspy")
+                return bytearray()
+            time.sleep(0.005)
 
-  def sync(self):
-    self.send_command(self.CMD_GET_STATE)
-    status = self.get_response(timeout=1)
-    if status == "OK":
-      log.info("subg_rfspy status: " + status)
+    def sync(self):
+        self.send_command(self.CMD_GET_STATE)
+        status = self.get_response(timeout=1)
+        if status == "OK":
+            log.info("subg_rfspy status: " + status)
 
-    self.send_command(self.CMD_GET_VERSION)
-    version = self.get_response(timeout=1)
-    if len(version) >= 3:
-      log.info("Version: " + version)
+        self.send_command(self.CMD_GET_VERSION)
+        version = self.get_response(timeout=1)
+        if len(version) >= 3:
+            log.info("Version: " + version)
 
-    if not status or not version:
-      raise CommsException("Could not get subg_rfspy state or version. Have you got the right port/device and radio_type?")
+        if not status or not version:
+            raise CommsException("Could not get subg_rfspy state or version. Have you got the right port/device and radio_type?")

--- a/mmeowlink/vendors/subg_rfspy_link.py
+++ b/mmeowlink/vendors/subg_rfspy_link.py
@@ -14,6 +14,11 @@ from .. exceptions import InvalidPacketReceived, CommsException, SubgRfspyVersio
 from serial_interface import SerialInterface
 from serial_rf_spy import SerialRfSpy
 
+try:
+  long
+except NameError:
+  long = int
+
 io  = logging.getLogger( )
 log = io.getChild(__name__)
 


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

Tests: https://travis-ci.com/cclauss/mmeowlink/builds